### PR TITLE
Fix for non-working slider in Firefox for Android

### DIFF
--- a/src/Geshem.css
+++ b/src/Geshem.css
@@ -25,5 +25,6 @@
   #slider {
     width: 80vw;
     margin-left: 8vw;
+    z-index: 10;
   }
 }


### PR DESCRIPTION
This adds a z-index value to the slider on mobile to fix the non-working slider in Firefox for Android.

Fixes #27